### PR TITLE
Enable api-key and add to headers when present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,21 @@ If a file is submitted to PolySwarm and the arbiters reach a quorum identifying 
 
 ## Options Panel
 
-In the Options Panel, there is a purple "P" logo for this module. On that options panel, the user can set the parameters of the SwarmIt module. These include
+In the Options Panel, there is a purple "P" logo for this module. On that options panel, the user can set the parameters of the SwarmIt module.
 
-* Submission API URL
-* API Key
-* NCT Amount to pay per submisison.
+### Submission API URL
 
-Note: currently the API key and NCT amount are visible, but not implemented, so you can ignore them.
+This is the url of the hosted service that will submit the user's files to polyswarm.
 
+*This must be a valid service.*
+
+### API Key
+
+Consumer on the PolySwarm staging and production environment is protected via API Key.
+Keys can be obtained from the PolySwarm team directly.
+
+If targeting a development environment, such as orchestration, leave this field blank.
+
+### NCT Amount to pay per submisison.
+
+*Note: currently NCT amount is visible, but not implemented, so you can ignore it.*

--- a/swarmit/src/io/polyswarm/swarmit/apiclient/BadRequestException.java
+++ b/swarmit/src/io/polyswarm/swarmit/apiclient/BadRequestException.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 PolySwarm PTE. LTD.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.polyswarm.swarmit.apiclient;
+
+import java.io.IOException;
+
+/**
+ *
+ * @author Rob
+ */
+public class BadRequestException extends IOException {
+    /**
+     * Constructs an instance of <code>BadRequestException</code> with the
+     * specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public BadRequestException(String msg) {
+        super(msg);
+    }
+}

--- a/swarmit/src/io/polyswarm/swarmit/apiclient/NotAuthorizedException.java
+++ b/swarmit/src/io/polyswarm/swarmit/apiclient/NotAuthorizedException.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 PolySwarm PTE. LTD.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.polyswarm.swarmit.apiclient;
+
+import java.io.IOException;
+
+/**
+ * On any 401 this exception should be thrown.
+ * Typically occurs when no API key is passed
+ */
+public class NotAuthorizedException extends IOException {
+    /**
+     * Constructs an instance of <code>NotAuthorizedException</code> with the
+     * specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public NotAuthorizedException(String msg) {
+        super(msg);
+    }
+}

--- a/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiClient.java
+++ b/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiClient.java
@@ -119,7 +119,7 @@ public class SwarmItApiClient {
      *
      * @throws IOException
      */
-    public static JSONObject getSubmissionStatus(String uuid) throws IOException, ClientProtocolException {
+    public static JSONObject getSubmissionStatus(String uuid) throws IOException, BadRequestException {
         CloseableHttpClient httpclient = HttpClients.createDefault();
         SwarmItMarketplaceSettings apiSettings = new SwarmItMarketplaceSettings();
 
@@ -134,6 +134,12 @@ public class SwarmItApiClient {
         } catch (URISyntaxException ex) {
             LOGGER.log(Level.SEVERE, "Invalid API URI.", ex);
             throw new IOException(ex);
+        } catch (NotAuthorizedException ex) {
+            LOGGER.log(Level.SEVERE, "Invalid API Key.", ex);
+            throw new IOException(ex);
+        } catch (BadRequestException ex) {
+            LOGGER.log(Level.SEVERE, "Invalid UUID.", ex);
+            throw new BadRequestException(ex.getMessage());
         } catch (IOException ex) {
             LOGGER.log(Level.SEVERE, "Error executing query.", ex);
             throw new IOException(ex);

--- a/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiClient.java
+++ b/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiClient.java
@@ -77,7 +77,12 @@ public class SwarmItApiClient {
         SwarmItMarketplaceSettings apiSettings = new SwarmItMarketplaceSettings();
 
         try {
+            String apikey = apiSettings.getApiKey();
             HttpPost httppost = new HttpPost(new URI(apiSettings.getApiUrl()));
+            if (apikey != null && !apikey.isEmpty()) {
+                httppost.addHeader("Authorization", apiSettings.getApiKey());
+            }
+            
             LOGGER.log(Level.INFO, "Submitting file with request {0}.", httppost.getRequestLine());
             InputStreamKnownSizeBody inputStreamBody = new InputStreamKnownSizeBody(
                     new ReadContentInputStream(abstractFile),

--- a/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiResponseHandler.java
+++ b/swarmit/src/io/polyswarm/swarmit/apiclient/SwarmItApiResponseHandler.java
@@ -38,7 +38,7 @@ public class SwarmItApiResponseHandler implements ResponseHandler<String> {
     private final static Logger LOGGER = Logger.getLogger(SwarmItApiResponseHandler.class.getName());
 
     @Override
-    public String handleResponse(HttpResponse response) throws ClientProtocolException, IOException {
+    public String handleResponse(HttpResponse response) throws NotAuthorizedException, BadRequestException, ClientProtocolException, IOException {
         Integer statusCode = response.getStatusLine().getStatusCode();
         HttpEntity responseEntity = response.getEntity();
         String responseString = null;
@@ -49,6 +49,10 @@ public class SwarmItApiResponseHandler implements ResponseHandler<String> {
         if (statusCode == 200) {
             return responseString;
 
+        } else if (statusCode == 401) {
+            throw new NotAuthorizedException(responseString);
+        } else if (statusCode == 400) {
+            throw new BadRequestException(responseString);
         } else {
             throw new ClientProtocolException(String.format("Client request failed. Status code: %s, Response: %s.", statusCode, responseString));
         }

--- a/swarmit/src/io/polyswarm/swarmit/optionspanel/Bundle.properties
+++ b/swarmit/src/io/polyswarm/swarmit/optionspanel/Bundle.properties
@@ -5,12 +5,9 @@ SwarmItPanel.nctAmountUnitLabel.text=NCT
 SwarmItPanel.defaultNctAmountTextField.text=0.5
 SwarmItPanel.apiUrlTitle.text=PolySwarm API URL
 SwarmItPanel.nctAmountTitle.text=Default NCT Payment (per artifact submission)
-SwarmItPanel.apiKeyErrorMsgLabel.text=Invalid API Key
-# To change this license header, choose License Headers in Project Properties.
-# To change this template file, choose Tools | Templates
-# and open the template in the editor.
-SwarmItPanel.apiKeyTextArea.toolTipText=JSON blob containing your PolySwarm API key and ETH keys
 SwarmItPanel.apiUrlTextField.toolTipText=Enter the URL for the PolySwarm API Service
 SwarmItPanel.apiUrlTextField.text=https://todo.todo.todo
 SwarmItPanel.apiUrlErrorMsgLabel.text=Invalid API URL
 SwarmItPanel.apiKeyTitle.text=PolySwarm API KEY
+SwarmItPanel.apiKeyErrorMsgLabel.text=Invalid API Key
+SwarmItPanel.apiKeyTextField.text=

--- a/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItMarketplaceSettings.java
+++ b/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItMarketplaceSettings.java
@@ -173,12 +173,10 @@ public final class SwarmItMarketplaceSettings {
      * @return true if valid and set, else false
      */
     public boolean setApiKey(String newApiKey) {
-//        if (newApiKey.isEmpty()) {
-//            return false;
-//        }
-//        apiKey = newApiKey;
-
-        apiKey = DEFAULT_API_KEY;
+        if (newApiKey.isEmpty()) {
+            return false;
+        }
+        apiKey = newApiKey;
         return true;
     }
     

--- a/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItMarketplaceSettings.java
+++ b/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItMarketplaceSettings.java
@@ -163,19 +163,13 @@ public final class SwarmItMarketplaceSettings {
     /**
      * Set the new API Key and test if it's valid.
      * 
-     * NOTE: API Key is not used in the current version.
-     * TODO: When it is used, uncomment the if test and implement
-     * some level of validation, like:
-     * - not empty
-     * - has valid api_key regex
+     * The service works with API Keys or without, depending on the setup
+     * We allow the user to clear the API key if they want
      * 
      * @param newApiKey New API Key
      * @return true if valid and set, else false
      */
     public boolean setApiKey(String newApiKey) {
-        if (newApiKey.isEmpty()) {
-            return false;
-        }
         apiKey = newApiKey;
         return true;
     }

--- a/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItPanel.form
+++ b/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItPanel.form
@@ -24,7 +24,7 @@
                   <Component id="testConnectionButtonPanel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="apiKeyPanel" alignment="0" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace pref="19" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -35,9 +35,9 @@
               <Component id="apiUrlPanel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="apiKeyPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="nctAmountPanel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="40" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
               <Component id="testConnectionButtonPanel" min="-2" max="-2" attributes="0"/>
               <EmptySpace min="-2" pref="35" max="-2" attributes="0"/>
           </Group>
@@ -66,7 +66,7 @@
                       <Component id="apiUrlTextField" min="-2" pref="588" max="-2" attributes="0"/>
                       <Component id="apiUrlErrorMsgLabel" alignment="0" min="-2" pref="576" max="-2" attributes="0"/>
                   </Group>
-                  <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace pref="54" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -132,7 +132,7 @@
               <Group type="102" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="apiKeyTextArea" min="-2" pref="567" max="-2" attributes="0"/>
+                      <Component id="apiKeyTextField" min="-2" pref="586" max="-2" attributes="0"/>
                       <Component id="apiKeyErrorMsgLabel" alignment="0" min="-2" pref="586" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
@@ -143,10 +143,10 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="1" attributes="0">
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="apiKeyTextArea" min="-2" max="-2" attributes="0"/>
+                  <Component id="apiKeyTextField" min="-2" max="-2" attributes="0"/>
                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Component id="apiKeyErrorMsgLabel" min="-2" pref="14" max="-2" attributes="0"/>
-                  <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace pref="16" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -165,13 +165,10 @@
             </Property>
           </Properties>
         </Component>
-        <Component class="javax.swing.JTextArea" name="apiKeyTextArea">
+        <Component class="javax.swing.JTextField" name="apiKeyTextField">
           <Properties>
-            <Property name="columns" type="int" value="20"/>
-            <Property name="rows" type="int" value="5"/>
-            <Property name="text" type="java.lang.String" value="ABCEDF1234567890" noResource="true"/>
-            <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-              <ResourceString bundle="io/polyswarm/swarmit/optionspanel/Bundle.properties" key="SwarmItPanel.apiKeyTextArea.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="io/polyswarm/swarmit/optionspanel/Bundle.properties" key="SwarmItPanel.apiKeyTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
             </Property>
           </Properties>
         </Component>

--- a/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItPanel.java
+++ b/swarmit/src/io/polyswarm/swarmit/optionspanel/SwarmItPanel.java
@@ -60,7 +60,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
         apiUrlErrorMsgLabel = new javax.swing.JLabel();
         apiKeyPanel = new javax.swing.JPanel();
         apiKeyErrorMsgLabel = new javax.swing.JLabel();
-        apiKeyTextArea = new javax.swing.JTextArea();
+        apiKeyTextField = new javax.swing.JTextField();
         nctAmountPanel = new javax.swing.JPanel();
         defaultNctAmountTextField = new javax.swing.JTextField();
         nctAmountUnitLabel = new javax.swing.JLabel();
@@ -88,7 +88,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
                 .addGroup(apiUrlPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(apiUrlTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 588, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(apiUrlErrorMsgLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 576, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(20, Short.MAX_VALUE))
+                .addContainerGap(54, Short.MAX_VALUE))
         );
         apiUrlPanelLayout.setVerticalGroup(
             apiUrlPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -107,10 +107,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
         apiKeyErrorMsgLabel.setForeground(new java.awt.Color(255, 0, 0));
         org.openide.awt.Mnemonics.setLocalizedText(apiKeyErrorMsgLabel, org.openide.util.NbBundle.getMessage(SwarmItPanel.class, "SwarmItPanel.apiKeyErrorMsgLabel.text")); // NOI18N
 
-        apiKeyTextArea.setColumns(20);
-        apiKeyTextArea.setRows(5);
-        apiKeyTextArea.setText("ABCEDF1234567890"); // NOI18N
-        apiKeyTextArea.setToolTipText(org.openide.util.NbBundle.getMessage(SwarmItPanel.class, "SwarmItPanel.apiKeyTextArea.toolTipText")); // NOI18N
+        apiKeyTextField.setText(org.openide.util.NbBundle.getMessage(SwarmItPanel.class, "SwarmItPanel.apiKeyTextField.text")); // NOI18N
 
         javax.swing.GroupLayout apiKeyPanelLayout = new javax.swing.GroupLayout(apiKeyPanel);
         apiKeyPanel.setLayout(apiKeyPanelLayout);
@@ -119,7 +116,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
             .addGroup(apiKeyPanelLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(apiKeyPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(apiKeyTextArea, javax.swing.GroupLayout.PREFERRED_SIZE, 567, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(apiKeyTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 586, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(apiKeyErrorMsgLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 586, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
@@ -127,10 +124,10 @@ final class SwarmItPanel extends javax.swing.JPanel {
             apiKeyPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, apiKeyPanelLayout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(apiKeyTextArea, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(apiKeyTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(apiKeyErrorMsgLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 14, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap(16, Short.MAX_VALUE))
         );
 
         nctAmountPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(null, org.openide.util.NbBundle.getMessage(SwarmItPanel.class, "SwarmItPanel.nctAmountTitle.text"), javax.swing.border.TitledBorder.DEFAULT_JUSTIFICATION, javax.swing.border.TitledBorder.DEFAULT_POSITION, new java.awt.Font("Tahoma", 0, 12))); // NOI18N
@@ -213,7 +210,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
                     .addComponent(nctAmountPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                     .addComponent(testConnectionButtonPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(apiKeyPanel, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                .addContainerGap(19, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -222,9 +219,9 @@ final class SwarmItPanel extends javax.swing.JPanel {
                 .addComponent(apiUrlPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(apiKeyPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(nctAmountPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 40, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(testConnectionButtonPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addGap(35, 35, 35))
         );
@@ -251,19 +248,18 @@ final class SwarmItPanel extends javax.swing.JPanel {
 
     private void customizeComponents() {
         // read settings and initialize GUI
-        apiKeyTextArea.setText(settings.getApiKey());
+        apiKeyTextField.setText(settings.getApiKey());
         apiUrlTextField.setText(settings.getApiUrl());
         defaultNctAmountTextField.setText(settings.getNctAmountString());
 
         // listen to changes in form fields and call controller.changed()
-        apiKeyTextArea.getDocument().addDocumentListener(new MyDocumentListener());
+        apiKeyTextField.getDocument().addDocumentListener(new MyDocumentListener());
         apiUrlTextField.getDocument().addDocumentListener(new MyDocumentListener());
         defaultNctAmountTextField.getDocument().addDocumentListener(new MyDocumentListener());
 
-        // NOTE: We've disabled the API KEY and DEFAULT NCT AMOUNT fields,
-        // since they are not currently used.
-        // TODO: remove these next 2 lines when they are to be used.
-        apiKeyTextArea.setEditable(false);
+        // NOTE: We've disabled the DEFAULT NCT AMOUNT fields,
+        // since it is not currently used.
+        // TODO: remove this lineswhen it is to be used.
         defaultNctAmountTextField.setEditable(false);
 
         connectionTestStatus = ConnectionTestResult.UNTESTED;
@@ -308,7 +304,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
      * @return true if valid, else false
      */
     boolean validApiKey() {
-        boolean isValid = settings.setApiKey(apiKeyTextArea.getText());
+        boolean isValid = settings.setApiKey(apiKeyTextField.getText());
         if (isValid == false) {
             apiKeyErrorMsgLabel.setText(NbBundle.getMessage(this.getClass(), "SwarmItPanel.apiKeyErrorMsgLabel.text"));
         }
@@ -406,7 +402,7 @@ final class SwarmItPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JLabel apiKeyErrorMsgLabel;
     private javax.swing.JPanel apiKeyPanel;
-    private javax.swing.JTextArea apiKeyTextArea;
+    private javax.swing.JTextField apiKeyTextField;
     private javax.swing.JLabel apiUrlErrorMsgLabel;
     private javax.swing.JPanel apiUrlPanel;
     private javax.swing.JTextField apiUrlTextField;


### PR DESCRIPTION
Pairs with https://github.com/polyswarm/consumer/pull/36

* Enable editing of the api key in the options panel
* Enable saving api keys to configuration
* Add api-keys as a header, when present.
